### PR TITLE
fix the Iris dataset by adding PCA

### DIFF
--- a/artificial_intelligence/datasets.py
+++ b/artificial_intelligence/datasets.py
@@ -376,6 +376,11 @@ def Iris(training_size, test_size, n, PLOT_DATA):
     sample_train = std_scale.transform(sample_train)
     sample_test = std_scale.transform(sample_test)
 
+    # Now reduce number of features to number of qubits
+    pca = PCA(n_components=n).fit(sample_train)
+    sample_train = pca.transform(sample_train)
+    sample_test = pca.transform(sample_test)
+
     # Scale to the range (-1,+1)
     samples = np.append(sample_train, sample_test, axis=0)
     minmax_scale = MinMaxScaler((-1, 1)).fit(samples)


### PR DESCRIPTION
PCA is for reducing the number of features to 2 or 3 so that the quantum code applies.
For instance, it is used in the dataset Wine, see Wine() in datasets.py.
However, it is not missing in the dataset Iris, see Iris() in datasets.py.
Therefore, we shall add the PCA support. 
