### PR TITLE
multiclass svm (one against all)

### DIFF
--- a/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+
+
+from datasets import *
+from qiskit_acqua.svm.data_preprocess import *
+from qiskit_acqua.input import get_input_instance
+from qiskit_acqua import run_algorithm
+
+
+
+sample_Total, training_input, test_input, class_labels = \
+Wine(training_size=20, test_size=10, n=2, # 2 is the dimension of each data point
+            PLOT_DATA=False)
+total_array, label_to_labelclass = get_points(test_input, class_labels)
+
+
+params = {
+    'problem': {'name': 'svm_classification'},
+    'algorithm': {
+        'name': 'ClassicalSVM_OneAgainstRest',
+        'print_info': True
+    }
+}
+
+algo_input = get_input_instance('SVMInput')
+algo_input.training_dataset = training_input
+algo_input.test_dataset = test_input
+algo_input.datapoints = total_array
+result = run_algorithm(params, algo_input)
+print(result)

--- a/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
@@ -41,6 +41,7 @@ params = {
 
 algo_input = get_input_instance('SVMInput')
 algo_input.training_dataset = training_input
+
 algo_input.test_dataset = test_input
 algo_input.datapoints = total_array
 result = run_algorithm(params, algo_input)

--- a/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
@@ -16,7 +16,7 @@
 # =============================================================================
 
 import sys
-sys.path.append("/Users/liup/quantum/qiskit-acqua-oneagainstrest-PR")# should be removed once being pulled!
+# sys.path.append("../../qiskit-acqua")# should be removed once being pulled!
 
 from datasets import *
 from qiskit_acqua.svm.data_preprocess import *

--- a/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/classicalsvm_multiclass_one_against_rest.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 # =============================================================================
 
-
+import sys
+sys.path.append("/Users/liup/quantum/qiskit-acqua-oneagainstrest-PR")# should be removed once being pulled!
 
 from datasets import *
 from qiskit_acqua.svm.data_preprocess import *
@@ -25,7 +26,7 @@ from qiskit_acqua import run_algorithm
 
 
 sample_Total, training_input, test_input, class_labels = \
-Wine(training_size=20, test_size=10, n=2, # 2 is the dimension of each data point
+Wine(training_size=40, test_size=10, n=2, # 2 is the dimension of each data point
             PLOT_DATA=False)
 total_array, label_to_labelclass = get_points(test_input, class_labels)
 

--- a/artificial_intelligence/datasets.py
+++ b/artificial_intelligence/datasets.py
@@ -407,8 +407,7 @@ def Wine(training_size, test_size, n, PLOT_DATA):
     class_labels = [r'A', r'B', r'C']
 
     data, target = datasets.load_wine(True)
-    sample_train, sample_test, label_train, label_test = train_test_split(data, target, test_size=0.1,
-                                                                          random_state=7)
+    sample_train, sample_test, label_train, label_test = train_test_split(data, target, test_size=test_size, random_state=7)
 
     # Now we standarize for gaussian around 0 with unit variance
     std_scale = StandardScaler().fit(sample_train)

--- a/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018 IBM.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+
+
+from datasets import *
+from qiskit_acqua.svm.data_preprocess import *
+from qiskit_acqua.input import get_input_instance
+from qiskit_acqua import run_algorithm
+
+
+
+sample_Total, training_input, test_input, class_labels = \
+Wine(training_size=20, test_size=10, n=2, # 2 is the dimension of each data point
+            PLOT_DATA=False)
+total_array, label_to_labelclass = get_points(test_input, class_labels)
+
+
+params = {
+    'problem': {'name': 'svm_classification'},
+    'backend': {'name': 'local_qasm_simulator', 'shots': 1000},
+
+    'algorithm': {
+        'name': 'QuantumSVM_OneAgainstRest',
+        'print_info': True
+    }
+}
+
+algo_input = get_input_instance('SVMInput')
+algo_input.training_dataset = training_input
+algo_input.test_dataset = test_input
+algo_input.datapoints = total_array
+result = run_algorithm(params, algo_input)
+print(result)

--- a/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
@@ -16,7 +16,7 @@
 # =============================================================================
 
 import sys
-sys.path.append("../../qiskit-acqua-oneagainstrest-PR")# should be removed once being pulled!
+# sys.path.append("../../qiskit-acqua")# should be removed once being pulled!
 
 from datasets import *
 from qiskit_acqua.svm.data_preprocess import *

--- a/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
+++ b/artificial_intelligence/quantumsvm_multiclass_one_against_rest.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 # =============================================================================
 
-
+import sys
+sys.path.append("../../qiskit-acqua-oneagainstrest-PR")# should be removed once being pulled!
 
 from datasets import *
 from qiskit_acqua.svm.data_preprocess import *
@@ -25,7 +26,7 @@ from qiskit_acqua import run_algorithm
 
 
 sample_Total, training_input, test_input, class_labels = \
-Wine(training_size=20, test_size=10, n=2, # 2 is the dimension of each data point
+Wine(training_size=40, test_size=10, n=2, # 2 is the dimension of each data point
             PLOT_DATA=False)
 total_array, label_to_labelclass = get_points(test_input, class_labels)
 


### PR DESCRIPTION
The examples for running the multiclass svm implementation merged to qiskit-acqua (in a separate PR)
This is for classical svm:
classicalsvm_multiclass_one_against_rest.py

This is for quantum svm:
quantumsvm_multiclass_one_against_rest.py

Note you may need to add the following to the .py files. 
import sys
sys.path.append("../../qiskit-acqua-oneagainstrest-PR")# should be removed once being pulled!